### PR TITLE
WebGpuMatrix implement has some issues. Will focus on Cpu and Cuda

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
-CppMatrix (experiment)
+CppMatrix
 ==
+Supported backed:
+
+* Cpu
+* Cuda
+* WebGpu (experiment)
+
+Supported type:
+
+* std::float16_t
+* std::float32_t
 
 ## Install Dependencies
 ### Install Cuda-Toolkit 12.8

--- a/example/mnist/main.cpp
+++ b/example/mnist/main.cpp
@@ -137,11 +137,11 @@ int main(int argc, char* argv[])
         }
     } else if (options.useWebGpuMatrix) {
         if (options.useF16) {
-            run(NeuralNetwork<WebGpuMatrix<std::float16_t>> { kInputNodes, kHiddenNodes, kOutputNodes,
+            run(NeuralNetwork<experiment::WebGpuMatrix<std::float16_t>> { kInputNodes, kHiddenNodes, kOutputNodes,
                     (std::float16_t)kLearningRate },
                 options);
         } else {
-            run(NeuralNetwork<WebGpuMatrix<std::float32_t>> { kInputNodes, kHiddenNodes, kOutputNodes,
+            run(NeuralNetwork<experiment::WebGpuMatrix<std::float32_t>> { kInputNodes, kHiddenNodes, kOutputNodes,
                     (std::float16_t)kLearningRate },
                 options);
         }

--- a/src/matrix.cpp
+++ b/src/matrix.cpp
@@ -172,8 +172,10 @@ private:
 export template <MatrixElementType T>
 using CpuMatrix = Matrix<backend::CpuMatrix<T>>;
 
-export template <MatrixElementType T>
-using WebGpuMatrix = Matrix<backend::WebGpuMatrix<T>>;
+namespace experiment {
+    export template <MatrixElementType T>
+    using WebGpuMatrix = Matrix<backend::WebGpuMatrix<T>>;
+}
 
 export template <MatrixElementType T>
 using CudaMatrix = Matrix<backend::CudaMatrix<T>>;
@@ -192,10 +194,10 @@ using CudaMatrix = Matrix<backend::CudaMatrix<T>>;
 #define Operators(M) \
     OperatorsElementType(M, std::float16_t) \
     OperatorsElementType(M, std::float32_t)
-
-Operators(CpuMatrix)
-Operators(CudaMatrix)
-Operators(WebGpuMatrix)
 // clang-format on
+
+Operators(CpuMatrix);
+Operators(CudaMatrix);
+Operators(experiment::WebGpuMatrix);
 
 }

--- a/test/matrix_test.cpp
+++ b/test/matrix_test.cpp
@@ -620,11 +620,6 @@ MATRIX_TEST(Relu)
 
 MATRIX_TEST(Pow)
 {
-    if (std::is_same_v<Matrix, cpp_matrix::WebGpuMatrix<std::float16_t>>
-        || std::is_same_v<Matrix, cpp_matrix::WebGpuMatrix<std::float32_t>>) {
-        GTEST_SKIP() << "WebGpuMatrix() is not supported Pow test due to precision.";
-    }
-
     auto test = [](size_t row, size_t column, Matrix::ElementType e) {
         Matrix x { row, column };
 

--- a/test/webgpu_matrix_float16_test.cpp
+++ b/test/webgpu_matrix_float16_test.cpp
@@ -3,8 +3,8 @@
 
 import cpp_matrix;
 
-using Matrix = cpp_matrix::WebGpuMatrix<std::float16_t>;
+using Matrix = cpp_matrix::experiment::WebGpuMatrix<std::float16_t>;
 
-#define MATRIX_TEST_NAME WebGpuMatrixFloat16Test
+#define MATRIX_TEST_NAME DISABLED_WebGpuMatrixFloat16Test
 
 #include "matrix_test.cpp"

--- a/test/webgpu_matrix_float32_test.cpp
+++ b/test/webgpu_matrix_float32_test.cpp
@@ -3,8 +3,8 @@
 
 import cpp_matrix;
 
-using Matrix = cpp_matrix::WebGpuMatrix<std::float32_t>;
+using Matrix = cpp_matrix::experiment::WebGpuMatrix<std::float32_t>;
 
-#define MATRIX_TEST_NAME WebGpuMatrixFloat32Test
+#define MATRIX_TEST_NAME DISABLED_WebGpuMatrixFloat32Test
 
 #include "matrix_test.cpp"


### PR DESCRIPTION
backend currently, so move WebGpuMatrix to experiment namespace and disable WebGpuMatrix tests by default. But we will keep to build WebGpuMatrix.